### PR TITLE
Add in table dependencies (quicker for user and more valid)

### DIFF
--- a/R/compare_sessions.R
+++ b/R/compare_sessions.R
@@ -4,8 +4,8 @@
 #' It compares csv outputs from two sessions, finds their differences, and asks for a consensus. \cr \cr
 #'
 #' @param session_dir This directory should contain 2 csv files for each session (LOG_ and OUTPUT_), 4 csv files in total.
-#' @param session1_base Base file name for session 1 e.g. 'NationalCommunityChildHealthDatabase(NCCHD)_BLOOD_TEST_2024-07-05_16-07-38.599493'
-#' @param session2_base Base file name for session 1 e.g. 'NationalCommunityChildHealthDatabase(NCCHD)_BLOOD_TEST_2024-07-08_12-03-30.429336'
+#' @param session1_base Base file name for session 1 e.g. 'NationalCommunityChildHealthDatabase(NCCHD)_BLOOD_TEST_2024-07-05-16-07-38'
+#' @param session2_base Base file name for session 1 e.g. 'NationalCommunityChildHealthDatabase(NCCHD)_BLOOD_TEST_2024-07-08-12-03-30'
 #' @param json_file The full path to the metadata file used when running domain_mapping (should be the same for session 1 and session 2)
 #' @param domain_file The full path to the domain file used when running domain_mapping (should be the same for session 1 and session 2)
 #' @return It returns a csv output, which represents the consensus decisions between session 1 and session 2

--- a/R/domain_mapping.R
+++ b/R/domain_mapping.R
@@ -58,18 +58,9 @@ domain_mapping <- function(json_file = NULL, domain_file = NULL, look_up_file = 
     print(lookup)
   }
 
-  # Check if previous table output exists in this output_dir (for table copying)
-  if (table_copy == TRUE){
-    dataset_search = paste0("^OUTPUT_",gsub(" ", "", meta_json$dataModel$label),'*')
-    csv_list <- data.frame(file = list.files(output_dir,pattern = dataset_search))
-    if (nrow(csv_list) != 0){
-      csv_list$date <- as.POSIXct(substring(csv_list$file,nchar(csv_list$file)-22,nchar(csv_list$file)-4), format="%Y-%m-%d-%H-%M-%S")
-      csv_last_filename <- csv_list[which.min(csv_list$date),]
-      csv_last <- read.csv(paste0(output_dir,csv_last_filename)$file)
-      csv_last_exist <- TRUE
-      cli_alert_info(paste0("Copying from previous session: ",csv_last_filename$file))
-    } else {csv_last_exist <- FALSE}
-    } else {csv_last_exist <- FALSE}
+  # If user has not provider output_dir, use current working dir:
+  if (is.null(output_dir)) {
+    output_dir = getwd() }
 
   ## Present domains plots panel for user's reference ----
   colnames(domains)[1] = "Domain Name"
@@ -140,6 +131,20 @@ domain_mapping <- function(json_file = NULL, domain_file = NULL, look_up_file = 
     cat(meta_json$dataModel$childDataClasses[[dc]]$label, fill = TRUE)
     cli_h1("Table Last Updated")
     cat(meta_json$dataModel$childDataClasses[[dc]]$lastUpdated, "\n", fill = TRUE)
+
+    # Check if previous table output exists in this output_dir (for table copying)
+    if (table_copy == TRUE){
+      dataset_search = paste0("^OUTPUT_",gsub(" ", "", meta_json$dataModel$label),'*')
+      csv_list <- data.frame(file = list.files(output_dir,pattern = dataset_search))
+      if (nrow(csv_list) != 0){
+        csv_list$date <- as.POSIXct(substring(csv_list$file,nchar(csv_list$file)-22,nchar(csv_list$file)-4), format="%Y-%m-%d-%H-%M-%S")
+        csv_last_filename <- csv_list[which.min(csv_list$date),]
+        csv_last <- read.csv(paste0(output_dir,'/',csv_last_filename$file))
+        csv_last_exist <- TRUE
+        cat("\n")
+        cli_alert_info(paste0("Copying from previous session: ",csv_last_filename$file))
+      } else {csv_last_exist <- FALSE}
+      } else {csv_last_exist <- FALSE}
 
     table_desc <- ""
     while (table_desc != "Y" & table_desc != "y" & table_desc != "N" & table_desc != "n") {
@@ -335,9 +340,6 @@ domain_mapping <- function(json_file = NULL, domain_file = NULL, look_up_file = 
 
     ## Save final categorisations for this Table  ----
     Output$timestamp <- timestamp_now
-    if (is.null(output_dir)) {
-      output_dir = getwd() }
-
     utils::write.csv(Output, paste(output_dir,output_fname_csv,sep='/'), row.names = FALSE)
     utils::write.csv(log_Output, paste(output_dir,output_fname_log_csv,sep='/'), row.names = FALSE)
     cat("\n")

--- a/R/domain_mapping.R
+++ b/R/domain_mapping.R
@@ -61,7 +61,7 @@ domain_mapping <- function(json_file = NULL, domain_file = NULL, look_up_file = 
   # Check if previous table output exists in this output_dir (for table copying)
   if (table_copy == TRUE){
     dataset_search = paste0("^OUTPUT_",gsub(" ", "", meta_json$dataModel$label),'*')
-    csv_list <- data.frame(file = list.files('.',pattern = dataset_search))
+    csv_list <- data.frame(file = list.files(output_dir,pattern = dataset_search))
     if (nrow(csv_list) != 0){
       csv_list$date <- as.POSIXct(substring(csv_list$file,nchar(csv_list$file)-22,nchar(csv_list$file)-4), format="%Y-%m-%d-%H-%M-%S")
       csv_last_filename <- csv_list[which.min(csv_list$date),]

--- a/R/domain_mapping.R
+++ b/R/domain_mapping.R
@@ -2,15 +2,15 @@
 #'
 #' This function will read in the metadata file for a chosen dataset, loop through all the data elements, and ask the user to catergorise/label each data element as belonging to one or more domains.\cr \cr
 #' The domains will appear in the Plots tab and dataset information will be printed to the R console, for the user's reference in making these categorisations. \cr \cr
-#' A log file will be saved with the catergorisations made.
-#' To speed up this process, some auto-categorisations will be made by the function for commonly occurring data elements. \cr \cr
+#' These categorisations will be saved to a csv file, alongside a log file which summarises the session details.
+#' To speed up this process, some auto-categorisations will be made by the function for commonly occurring data elements and categorisations for the same data element can be copied from one table to another. \cr \cr
 #' Example inputs are provided within the package data, for the user to run this function in a demo mode.
 #' @param json_file The metadata file. This should be downloaded from the metadata catalogue as a json file. See 'data-raw/maternity_indicators_dataset_(mids)_20240105T132210.json' for an example download.
 #' @param domain_file The domain list file. This should be a csv file created by the user, with each domain listed on a separate line. See 'data-raw/domain_list_demo.csv' for a template.
 #' @param look_up_file The look-up table file, with auto-categorisations. By default, the code uses 'data/look-up.rda'. The user can provide their own look-up table in the same format as 'data-raw/look-up.csv'.
-#' @param output_dir The path to the directory where the csv output log will be saved. By default, the current working directory is used.
+#' @param output_dir The path to the directory where the two csv output files will be saved. By default, the current working directory is used.
 #' @param table_copy Turn on copying between tables (TRUE or FALSE, default TRUE). If TRUE, categorisations you make for the last table you processed will be carried over to another, as long as the csv files share an output_dir.
-#' @return The function will return a log file with the mapping between data elements and domains, alongside details about the dataset.
+#' @return The function will return two csv files: 'OUTPUT_' which contains the mappings and 'LOG_' which contains details about the dataset and session.
 #' @examples
 #' # Run in demo mode by providing no inputs: domain_mapping()
 #' # Demo mode will use the /data files provided in this package

--- a/R/domain_mapping.R
+++ b/R/domain_mapping.R
@@ -64,8 +64,8 @@ domain_mapping <- function(json_file = NULL, domain_file = NULL, look_up_file = 
     csv_list <- data.frame(file = list.files(output_dir,pattern = dataset_search))
     if (nrow(csv_list) != 0){
       csv_list$date <- as.POSIXct(substring(csv_list$file,nchar(csv_list$file)-22,nchar(csv_list$file)-4), format="%Y-%m-%d-%H-%M-%S")
-      csv_last_filename <- paste0(output_dir,csv_list[which.min(csv_list$date),])
-      csv_last <- read.csv(csv_last_filename$file)
+      csv_last_filename <- csv_list[which.min(csv_list$date),]
+      csv_last <- read.csv(paste0(output_dir,csv_last_filename)$file)
       csv_last_exist <- TRUE
       cli_alert_info(paste0("Copying from previous session: ",csv_last_filename$file))
     } else {csv_last_exist <- FALSE}

--- a/R/domain_mapping.R
+++ b/R/domain_mapping.R
@@ -64,7 +64,7 @@ domain_mapping <- function(json_file = NULL, domain_file = NULL, look_up_file = 
     csv_list <- data.frame(file = list.files(output_dir,pattern = dataset_search))
     if (nrow(csv_list) != 0){
       csv_list$date <- as.POSIXct(substring(csv_list$file,nchar(csv_list$file)-22,nchar(csv_list$file)-4), format="%Y-%m-%d-%H-%M-%S")
-      csv_last_filename <- csv_list[which.min(csv_list$date),]
+      csv_last_filename <- paste0(output_dir,csv_list[which.min(csv_list$date),])
       csv_last <- read.csv(csv_last_filename$file)
       csv_last_exist <- TRUE
       cli_alert_info(paste0("Copying from previous session: ",csv_last_filename$file))

--- a/README.md
+++ b/README.md
@@ -290,11 +290,11 @@ All finished! Take a look at the outputs:
 
 ```
 ✔ Your final categorisations have been saved:
-OUTPUT_NationalCommunityChildHealthDatabase(NCCHD)_CHILD_2024-04-05_14-37-36.csv
+OUTPUT_NationalCommunityChildHealthDatabase(NCCHD)_CHILD_2024-04-05-14-37-36.csv
 ✔ Your session log has been saved:
-LOG_NationalCommunityChildHealthDatabase(NCCHD)_CHILD_2024-04-05_14-37-36.csv
+LOG_NationalCommunityChildHealthDatabase(NCCHD)_CHILD_2024-04-05-14-37-36.csv
 ✔ A summary plot has been saved:
-PLOT_NationalCommunityChildHealthDatabase(NCCHD)_CHILD_2024-04-05_14-37-36.png
+PLOT_NationalCommunityChildHealthDatabase(NCCHD)_CHILD_2024-04-05-14-37-36.png
 ```
 
 The OUTPUT csv contains the categorisations you made. The LOG csv contains information about the session as a whole, including various metadata. 

--- a/man/compare_sessions.Rd
+++ b/man/compare_sessions.Rd
@@ -15,9 +15,9 @@ compare_sessions(
 \arguments{
 \item{session_dir}{This directory should contain 2 csv files for each session (LOG_ and OUTPUT_), 4 csv files in total.}
 
-\item{session1_base}{Base file name for session 1 e.g. 'NationalCommunityChildHealthDatabase(NCCHD)_BLOOD_TEST_2024-07-05_16-07-38.599493'}
+\item{session1_base}{Base file name for session 1 e.g. 'NationalCommunityChildHealthDatabase(NCCHD)_BLOOD_TEST_2024-07-05-16-07-38'}
 
-\item{session2_base}{Base file name for session 1 e.g. 'NationalCommunityChildHealthDatabase(NCCHD)_BLOOD_TEST_2024-07-08_12-03-30.429336'}
+\item{session2_base}{Base file name for session 1 e.g. 'NationalCommunityChildHealthDatabase(NCCHD)_BLOOD_TEST_2024-07-08-12-03-30'}
 
 \item{json_file}{The full path to the metadata file used when running domain_mapping (should be the same for session 1 and session 2)}
 

--- a/man/domain_mapping.Rd
+++ b/man/domain_mapping.Rd
@@ -19,18 +19,18 @@ domain_mapping(
 
 \item{look_up_file}{The look-up table file, with auto-categorisations. By default, the code uses 'data/look-up.rda'. The user can provide their own look-up table in the same format as 'data-raw/look-up.csv'.}
 
-\item{output_dir}{The path to the directory where the csv output log will be saved. By default, the current working directory is used.}
+\item{output_dir}{The path to the directory where the two csv output files will be saved. By default, the current working directory is used.}
 
 \item{table_copy}{Turn on copying between tables (TRUE or FALSE, default TRUE). If TRUE, categorisations you make for the last table you processed will be carried over to another, as long as the csv files share an output_dir.}
 }
 \value{
-The function will return a log file with the mapping between data elements and domains, alongside details about the dataset.
+The function will return two csv files: 'OUTPUT_' which contains the mappings and 'LOG_' which contains details about the dataset and session.
 }
 \description{
 This function will read in the metadata file for a chosen dataset, loop through all the data elements, and ask the user to catergorise/label each data element as belonging to one or more domains.\cr \cr
 The domains will appear in the Plots tab and dataset information will be printed to the R console, for the user's reference in making these categorisations. \cr \cr
-A log file will be saved with the catergorisations made.
-To speed up this process, some auto-categorisations will be made by the function for commonly occurring data elements. \cr \cr
+These categorisations will be saved to a csv file, alongside a log file which summarises the session details.
+To speed up this process, some auto-categorisations will be made by the function for commonly occurring data elements and categorisations for the same data element can be copied from one table to another. \cr \cr
 Example inputs are provided within the package data, for the user to run this function in a demo mode.
 }
 \examples{

--- a/man/domain_mapping.Rd
+++ b/man/domain_mapping.Rd
@@ -8,7 +8,8 @@ domain_mapping(
   json_file = NULL,
   domain_file = NULL,
   look_up_file = NULL,
-  output_dir = NULL
+  output_dir = NULL,
+  table_copy = TRUE
 )
 }
 \arguments{
@@ -19,6 +20,8 @@ domain_mapping(
 \item{look_up_file}{The look-up table file, with auto-categorisations. By default, the code uses 'data/look-up.rda'. The user can provide their own look-up table in the same format as 'data-raw/look-up.csv'.}
 
 \item{output_dir}{The path to the directory where the csv output log will be saved. By default, the current working directory is used.}
+
+\item{table_copy}{Turn on copying between tables (TRUE or FALSE, default TRUE). If TRUE, categorisations you make for the last table you processed will be carried over to another, as long as the csv files share an output_dir.}
 }
 \value{
 The function will return a log file with the mapping between data elements and domains, alongside details about the dataset.


### PR DESCRIPTION
Closes #63 

Copying from one table to the next will save the user time, and ensure consistency of categorisations across tables

<!-- Add a short description of the PR here - what you have changed and why -->

## Proposed Changes
<!-- List major changes here, so that the reviewers can have a bit more context -->
  -  (MINOR) dates are saved with less precision (2024-07-05_16-07-38.599493 --> 2024-07-05_16-07-38)
  - (MINOR) cli_alert_success replaced with cli_alert_info for more consistent console output
  - a new input to `domain_mapping` has been added (`table_copy`) - see the description of this argument in the function itself and the explanation in the README of what table copying means (particularly lines 348 onwards)
  - updated `domain_mapping` docs in general, to reflect some recent changes

**In order to test the code you will need to process multiple tables**

This is an example of how the copying should work (ignore the actual domain code values):

<img width="1860" alt="Screenshot 2024-07-17 at 12 05 38" src="https://github.com/user-attachments/assets/1cc65c51-7177-40a4-a047-58f0f17fe26c">


## Checklist before review:
<!-- You're invited to open a draft PR so people can see what you are working on sooner -->
- [x] Please comment on my PR while it's a draft and give me feedback on the development!
- [x] I added everything I wanted to add to this PR, please review!
- [x] The title of this PR is clear and self-explantory.
- [x] I added any appropriate labels to this PR.
